### PR TITLE
Fixes Custom CBs

### DIFF
--- a/common/casus_belli_types/BNO_casus_belli.txt
+++ b/common/casus_belli_types/BNO_casus_belli.txt
@@ -1,5 +1,5 @@
 ﻿bno_war = {
-	group = religious
+	group = religious_disorganised
 	icon = religious_war
 	
 	combine_into_one = yes
@@ -113,7 +113,7 @@
 }
 
 bno_subj_war = {
-	group = religious
+	group = religious_disorganised
 	icon = invasion
 	
 	combine_into_one = yes
@@ -267,7 +267,7 @@ bno_subj_war = {
 
 bno_varangian_adventure = {
 	icon = fp1_varangian_adventurer_conquest
-	group = religious
+	group = religious_disorganised
 	
 	combine_into_one = yes
 	should_show_war_goal_subview = yes


### PR DESCRIPTION
The CBs included in this mod do not work because they have the line group = religious which requires that the attacker be part of a reformed religion. This changes the group of the CBs to conquest making them much more flexible.