### PR TITLE
Changes the BBC Rarity Rule

### DIFF
--- a/common/decisions/BNO_decisions.txt
+++ b/common/decisions/BNO_decisions.txt
@@ -309,3 +309,41 @@ bno_change_county_culture = {
         bno_decision_modifier = yes
 	}
 }
+
+
+#decision for player african males to gain the BBC trait if they dont already have it. This is so players dont get forced out of desired erotic content.
+bno_realize_bbc_potential = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_recruitment.dds"
+	}
+	sort_order = 10
+	decision_group_type = major
+	desc = bno_realize_bbc_potential.desc
+	selection_tooltip = bno_realize_bbc_potential_decision_tooltip
+	is_shown = {
+		is_ruler = yes
+		is_adult = yes
+		is_ai = no
+		OR = {
+			has_trait = bno_full_black
+			has_trait = bno_mostly_black
+			has_trait = bno_mixed
+			has_trait = bno_barely_mixed # even just slightly mixed PCs should have the chance to switch into BBC playstyle, I suppose.
+		} 
+		NOT = {
+			has_trait = bno_bbc
+		}
+		
+	}
+	cooldown = {
+		years = 5
+	}
+	cost = {
+		piety = 25
+	}
+	effect = {
+		add_trait = bno_bbc
+	}
+	ai_will_do = 0
+
+}

--- a/common/game_rules/00_bno_game_rules.txt
+++ b/common/game_rules/00_bno_game_rules.txt
@@ -163,7 +163,7 @@ bno_rarity = {
 		interaccial_takeover
 	}
 
-	default = bno_rarity_always
+	default = bno_rarity_race
 
 
 	bno_rarity_never = {
@@ -186,4 +186,11 @@ bno_rarity = {
 
 	}
 
+	bno_rarity_size = {
+
+	}
+
+	bno_rarity_race = {
+		
+	}
 }

--- a/common/script_values/bno_script_values.txt
+++ b/common/script_values/bno_script_values.txt
@@ -53,3 +53,90 @@ bno_younger_adult = {
 bno_young_adult = {
   value = { 21 39 }
 }
+
+
+bno_bbc_trait_occurance_chance = {
+  value = 0
+  if = {
+    limit = {
+		  has_game_rule = bno_rarity_always
+    }
+		value = 100		
+	}
+  if = {
+    limit = {
+		  has_game_rule = bno_rarity_often
+    }
+		value = 50
+	}
+  if = {
+    limit = {
+		  has_game_rule = bno_rarity_sometimes
+    }
+		value = 25
+	}
+  if = {
+    limit = {
+		  has_game_rule = bno_rarity_rare
+    }
+		value = 5
+	}
+  if = {
+    limit = {
+		  has_game_rule = bno_rarity_size
+    }
+		value = bno_bbc_trait_occurance_dicksize_modifier
+	}
+  if = {
+    limit = {
+		  has_game_rule = bno_rarity_race
+    }
+		value = bno_bbc_trait_occurance_dicksize_modifier
+    multiply = bno_bbc_trait_occurance_race_modifier
+	}
+}
+
+bno_bbc_trait_occurance_dicksize_modifier = { # Represents % chance of BBC occuring based on dicksize
+	value = 0
+	if = {
+    limit = {
+		  has_trait = dick_big_good_3
+    }
+		value = 100		
+	}
+	if = {
+    limit = {
+		  has_trait = dick_big_good_2
+    }
+		value = 50		
+	}
+  if = {
+    limit = {
+		  has_trait = dick_big_good_3
+    }
+		value = 25		
+	}
+}
+
+bno_bbc_trait_occurance_race_modifier = { # represents the multiplier applied to the BBC chance based on race
+	value = 0 
+	if = { #Full Black = No debuff to BBC chance
+    limit = {
+		  has_trait = bno_full_black 
+    }
+		value = 1
+	}
+	if = { #75% Black means 25% debuff to BBC chance
+    limit = {
+		  has_trait = bno_mostly_black
+    }
+		value = 0.75		
+	}
+  if = { #50% Black means 50% debuff to BBC chance
+    limit = {
+		  has_trait = bno_mixed
+    }
+		value = 0.5		
+	}
+  
+}

--- a/common/scripted_modifiers/bno_scripted_modifiers.txt
+++ b/common/scripted_modifiers/bno_scripted_modifiers.txt
@@ -120,44 +120,6 @@
 	}
 }
 
-bno_bbc_trait_occurance_chance_modifier = {
-	modifier = {
-		add = 100
-		trigger = { has_game_rule = bno_rarity_always }
-	}
-	modifier = {
-		add = 50
-		trigger = { has_game_rule = bno_rarity_often }
-	}
-	modifier = {
-		add = 25
-		trigger = { has_game_rule = bno_rarity_sometimes }
-	}
-	modifier = {
-		add = 5
-		trigger = { has_game_rule = bno_rarity_rare }
-	}
-}
-
-bno_bbc_trait_counter_occurance_chance_modifier = {
-	modifier = {
-		add = 100
-		trigger = { has_game_rule = bno_rarity_never }
-	}
-	modifier = {
-		add = 50
-		trigger = { has_game_rule = bno_rarity_often }
-	}
-	modifier = {
-		add = 75
-		trigger = { has_game_rule = bno_rarity_sometimes }
-	}
-	modifier = {
-		add = 95
-		trigger = { has_game_rule = bno_rarity_rare }
-	}
-}
-
 bno_decision_modifier = {
 	modifier = {
         add = 25

--- a/events/BNO_trait_maintenance_events.txt
+++ b/events/BNO_trait_maintenance_events.txt
@@ -11,26 +11,18 @@ bno_trait_maintenance.0001 = {
 			has_trait = bno_mostly_black
 			has_trait = bno_full_black
 		}
-		NOT = { has_character_flag = no_bbc }
 		is_male = yes
 		is_adult = yes
-	}
-	option = {
-		ai_chance = {
-			base = 0
-			bno_bbc_trait_counter_occurance_chance_modifier = yes
-		}
-		add_character_flag = {
-			flag = no_bbc
-			years = 5
+		NOT = {
+			has_character_flag = no_bbc_maint
 		}
 	}
-	option = {
-		ai_chance = {
-			base = 0
-			bno_bbc_trait_occurance_chance_modifier = yes
+	immediate = {
+		random = {
+			chance = bno_bbc_trait_occurance_chance
+			add_trait = bno_bbc
 		}
-		add_trait = bno_bbc
+		add_character_flag = no_bbc_maint #once a character has been checked it should never happen again.
 	}
 }
 
@@ -126,10 +118,11 @@ bno_trait_maintenance.0005 = {
 #all africans have black trait
 bno_trait_maintenance.0006 = {
 	hidden = yes
-	
 	trigger = {
+		has_game_rule = bno_mod_status_on
+		has_game_rule = bno_seeding_yes
 		is_ai = yes
-		bno_is_graphically_african = yes
+		bno_is_graphically_african = ye
 		NOR = {
 			has_trait = bno_mixed
 			has_trait = bno_mostly_black

--- a/localization/english/event_localization/BNO_bbc_events_l_english.yml
+++ b/localization/english/event_localization/BNO_bbc_events_l_english.yml
@@ -48,3 +48,11 @@
 
 bno_events.0006.title: "Your Chosen Noble Woman"
 bno_events.0006.desc: "#weak As the curious noble approaches my court, I greet her with a warm smile and extend an invitation. #!\n\nWelcome, [target1.GetFirstName], [target3.GetFirstName] or [target2.GetFirstName]. Your presence here is a great honor.\n\n#weak The noble looks around in awe as she takes in the grandeur of my estate - from the opulent furnishings to the priceless works of art that adorn every wall. #!\n\nI am pleased you have accepted my invitation. I look forward to sharing with you some of these treasures and learning more about your own interests in culture and the arts.\n\n#weak The noble nods respectfully, clearly grateful for the opportunity to explore this new world before her. #!"
+
+
+# bno_realize_bbc_potential Non-BBC Black character gains BBC
+bno_realize_bbc_potential: "Discover your BBC "
+bno_realize_bbc_potential.desc: "You realize your dominant black body gives you innate supremacy over the inferior sub-races. It's time to make Europe your bitch."
+bno_realize_bbc_potential_decision_tooltip: "You will become a dominant black stud."
+bno_realize_bbc_potential_confirm: "The world is mine."
+bno_realize_bbc_potential_effect_1: "You will gain the BBC Trait."

--- a/localization/english/game_rules/bno_game_rules_l_english.yml
+++ b/localization/english/game_rules/bno_game_rules_l_english.yml
@@ -71,3 +71,9 @@ setting_bno_rarity_often: "Often"
 setting_bno_rarity_often_desc: "I can't get enough of those #V [GetTrait('bno_bbc').GetName( GetNullCharacter )]#! ! The more often I can have them, the better."
 setting_bno_rarity_always: "Always"
 setting_bno_rarity_always_desc: "I need #V [GetTrait('bno_bbc').GetName( GetNullCharacter )]#!s in my life at all times. They are the only thing that can satisfy my insatiable hunger for #V [GetTrait('bno_bbc').GetName( GetNullCharacter )]#! ."
+
+setting_bno_rarity_size: "Size Matters"
+setting_bno_rarity_size_desc: "Dicks come in all shapes and sizes! I want the biggest #V [GetTrait('bno_bbc').GetName( GetNullCharacter )]#!s\n(The BBC trait will be more common in Africans based on dick size.)
+
+setting_bno_rarity_race: "Black is Bigger"
+setting_bno_rarity_race_desc: "The rumors are true! The blacker the berries the bigger the #V [GetTrait('bno_bbc').GetName( GetNullCharacter )]#!s get! (The BBC trait will be more common based on African purity and dick size)"


### PR DESCRIPTION
This PR adds two new choices to the BBC Rarity rule.

 'Size Matters' which assigns the BBC trait based on the following:

100% chance for mixed, mostly or fully black chars with big_dick_3 50% chance for mixed, mostly or fully black chars with big_dick_2 25% chance for mixed, mostly or fully black chars with big_dick_1

And the 'Black is Better' ruleset which assigns the BBC trait based on the following: 1.0 Multiplier for full black
0.75 multiplier for mostly black
0.5 multiplier for half black
multiplied with the percentages based on the dick-size rule so that a half-black big_dick_1 char has a 25% chance to get the trait, a half-black big_dick_3 has a 50% chance to get the trait, and a full_black big_dick_1 has a 50% chance to get the trait.

The original rule options have been maintained.

Additionally, this adds a decision that only players can use when playing a male, adult character with at least partial mixed race but no BBC trait which grants the BBC trait.

Additionally, this fixes the "Trait Seeding" rule so that it doesn't seed the African trait if the mod is disabled or if trait seeding is set to no.