### PR TITLE
Add BNO exp to bno_bull.0004

### DIFF
--- a/events/BNO_bull_events.txt
+++ b/events/BNO_bull_events.txt
@@ -423,6 +423,9 @@ bno_bull.0004 = {
 		bno_have_sex_with_effects = {
 			PARTNER = scope:target1
 		}
+		scope:target1 = {
+			bno_increase_sluttyness = yes
+		}
 	}
 
 	option = {


### PR DESCRIPTION
Adds BNO exp to the woman character involved in event bno_bull.0004 which makes it more interesting and helps prevent the event from repeating too much.