### PR TITLE
Adds bno_seeding_yes check to bno_trait_maintenance.0006

### DIFF
--- a/events/BNO_trait_maintenance_events.txt
+++ b/events/BNO_trait_maintenance_events.txt
@@ -96,6 +96,7 @@ bno_trait_maintenance.0006 = {
 	hidden = yes
 	trigger = {
 		has_game_rule = bno_mod_status_on
+		has_game_rule = bno_seeding_yes
 		is_ai = yes
 		bno_is_graphically_african = yes
 		NOR = {


### PR DESCRIPTION
Currently if bno_seeding the bno_trait_seeding rule is set to no the initial trait seeding pulse will be blocked but both bno_trait_seeding.0001 and bno_trait_maintenance.0006 will run through on_action triggers. The bno_trait_seeding therefore has no effect.

This PR adds a requirement that trait seeding be turned on for graphical Africans to be seeded with the Black trait. This makes the trait seeding rule function as it is implied to by the description and gives options for players who want a very localized campaign to manually seed the trait themselves.

Furthermore, this lays the groundwork for future variations on the trait seeding rule such as an "African Kings" trait seeding variation where only the rulers of the largest realms in Africa are automatically seeded with 'Black'.