### PR TITLE
Update bno_court_position.txt

### DIFF
--- a/common/court_positions/types/bno_court_position.txt
+++ b/common/court_positions/types/bno_court_position.txt
@@ -42,7 +42,6 @@
             }
             has_trait = bno_whitegirl
             has_trait = beauty_good
-            has_trait = tits_big_good
             age < 30
             NOT = { has_trait = lovers_pox }
         }


### PR DESCRIPTION
removing tits_big_good trait from valid bbc worshippers as it causes them to instantly leave position as soon as hired